### PR TITLE
skip the test_process_metadata_file

### DIFF
--- a/tests/test_process_metadata_file.py
+++ b/tests/test_process_metadata_file.py
@@ -227,6 +227,7 @@ def test_read_save_dataframe_as_tsv_error(dataframe: pd.DataFrame, tmp_path: str
     with pytest.raises(ValueError, match = r"Unsupported file format. Please point to a TSV file."):
         save_dataframe_as_tsv(dataframe, out_path)
 
+@pytest.mark.skip(reason="Test fails due to a inconsistency in the input file (metadata)")
 def test_process_metadata_file(processed_dataframe: pd.DataFrame, tmp_path: str):
     file_path = os.path.join("tests", "test_data", "batch_specification1.csv")
     out_path = os.path.join(tmp_path, "processed_batch_specification1.tsv")


### PR DESCRIPTION
Skipping the test_process_metadata_file was cherry-picked from the PR #21 